### PR TITLE
fix #310, onFinish outside the slider

### DIFF
--- a/js/ion.rangeSlider.js
+++ b/js/ion.rangeSlider.js
@@ -724,7 +724,6 @@
             this.$cache.cont.find(".state_hover").removeClass("state_hover");
 
             this.force_redraw = true;
-            this.dragging = false;
 
             if (is_old_ie) {
                 $("*").prop("unselectable", false);
@@ -738,6 +737,8 @@
                 this.is_finish = true;
                 this.callOnFinish();
             }
+            
+            this.dragging = false;
         },
 
         /**


### PR DESCRIPTION
In the pointerUp function, the callOnFinish() callback is call if we release the click inside the slider or if we are in dragging mode, line 736.

Unfortunately, the dragging mode is set to false just before ! line 727.

And the onFinish is never call
http://jsfiddle.net/sbx6zcnm/3/

I have move the `this.dragging = false` at the end of the function and it works fine, but I don't know all the consequences !

http://jsfiddle.net/sbx6zcnm/4/
